### PR TITLE
WIP: Add support for missing C11/GCC features

### DIFF
--- a/lib/perl5/App/Cilly.pm.in
+++ b/lib/perl5/App/Cilly.pm.in
@@ -2212,7 +2212,7 @@ sub setVersion {
          . join(' ', @{$self->{PPARGS}}) ." |") 
         || die "Cannot start GNUCC";
     while(<VER>) {
-        if($_ =~ m|^(\d+\S+)| || $_ =~ m|^(egcs-\d+\S+)|) {
+        if($_ =~ m|^(\d+\S+)| || $_ =~ m|^(\d+)$| || $_ =~ m|^(egcs-\d+\S+)|) {
             $cversion = "gcc_$1";
             close(VER) || die "Cannot start GNUCC\n";
             $self->{CVERSION} = $cversion;

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2714,7 +2714,7 @@ let parseInt (str: string) : exp =
     let l = String.length str in
     fun s -> 
       let ls = String.length s in
-      l >= ls && s = String.uppercase (String.sub str (l - ls) ls)
+      l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
   in
   let l = String.length str in
   (* See if it is octal or hex *)
@@ -5089,19 +5089,19 @@ let loadBinaryFile (filename : string) : file =
 (* Take the name of a file and make a valid symbol name out of it. There are 
  * a few characters that are not valid in symbols *)
 let makeValidSymbolName (s: string) = 
-  let s = String.copy s in (* So that we can update in place *)
   let l = String.length s in
+  let s = Bytes.of_string s in (* So that we can update in place *)
   for i = 0 to l - 1 do
-    let c = String.get s i in
+    let c = Bytes.get s i in
     let isinvalid = 
       match c with
         '-' | '.' -> true
       | _ -> false
     in
     if isinvalid then 
-      String.set s i '_';
+      Bytes.set s i '_';
   done;
-  s
+  Bytes.to_string s
 
 let rec addOffset (toadd: offset) (off: offset) : offset =
   match off with

--- a/src/formatlex.mll
+++ b/src/formatlex.mll
@@ -145,11 +145,11 @@ let scan_oct_escape str =
  * We convert L"Hi" to "H\000i\000" *)
 let wbtowc wstr =
   let len = String.length wstr in 
-  let dest = String.make (len * 2) '\000' in 
-  for i = 0 to len-1 do 
-    dest.[i*2] <- wstr.[i] ;
+  let dest = Bytes.of_string (String.make (len * 2) '\000') in 
+  for i = 0 to len-1 do
+      Bytes.set dest (i*2) wstr.[i];
   done ;
-  dest
+  Bytes.to_string dest
 
 (* This function converst the "Hi" in L"Hi" to { L'H', L'i', L'\0' } *)
 let wstr_to_warray wstr =

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -38,7 +38,7 @@
 (** This file was originally part of Hugues Casee's frontc 2.0, and has been 
  * extensively changed since. 
 **
-** 1.0	3.22.99	Hugues Cassé	First version.
+** 1.0	3.22.99	Hugues CassÈ	First version.
 ** 2.0  George Necula 12/12/00: Many extensions
  **)
 
@@ -174,7 +174,7 @@ and definition =
  | TRANSFORMER of definition * definition list * cabsloc
  (* expression transformer: source and destination *)
  | EXPRTRANSFORMER of expression * expression * cabsloc
-
+ | STATIC_ASSERT of expression * string option * cabsloc
 
 (* the string is a file name, and then the list of toplevel forms *)
 and file = string * definition list
@@ -277,7 +277,7 @@ and expression =
   | MEMBEROFPTR of expression * string
   | GNU_BODY of block
   | EXPR_PATTERN of string     (* pattern variable, and name *)
-  | GENERIC of expression * (((specifier * decl_type) option * expression) list) 
+  | GENERIC of expression * ((specifier * decl_type) option * expression) list
 
 and constant =
   | CONST_INT of string   (* the textual representation *)

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -38,7 +38,7 @@
 (** This file was originally part of Hugues Casee's frontc 2.0, and has been 
  * extensively changed since. 
 **
-** 1.0	3.22.99	Hugues Cassé	First version.
+** 1.0	3.22.99	Hugues CassÃ©	First version.
 ** 2.0  George Necula 12/12/00: Many extensions
  **)
 
@@ -277,6 +277,7 @@ and expression =
   | MEMBEROFPTR of expression * string
   | GNU_BODY of block
   | EXPR_PATTERN of string     (* pattern variable, and name *)
+  | GENERIC of expression * (((specifier * decl_type) option * expression) list) 
 
 and constant =
   | CONST_INT of string   (* the textual representation *)

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4038,7 +4038,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
     end
 
     | A.GENERIC (e, lst) ->
-      let compare_types t_1 t_2 =
+        let compare_types t_1 t_2 =
           match t_1, t_2 with
             | Some t_1', Some t_2'  -> compareTypesNoAttributes t_1' t_2'
             | _                     -> false
@@ -4057,7 +4057,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
         lst in
 
         (* Find the type of the value fed to the generic expression (T above). *)
-        let (chunk, expr, t_typ) = doExp false e (AExp None) in
+        let (_, _, t_typ) = doExp false e (AExp None) in
         
         (* Find the matching type in the type matches. *)
         let found_match = List.find_opt (fun (match_type, e) -> compare_types (Some t_typ) match_type) mapped in
@@ -4072,7 +4072,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
           | None, Some((None, exp)) -> doExp false exp (AExp None)
           (* No types matched, raise an error.
              We should hopefully see a compile time error before we reach this case. *)
-          | _ -> E.s (error "Could not find matching type for %a in _Generic @" d_plaintype t_typ)
+          | _ -> E.s (error "Could not find matching type for %a in _Generic" d_plaintype t_typ)
         in
         res
 
@@ -5750,6 +5750,7 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
   | A.TRANSFORMER (_, _, _) -> E.s (E.bug "TRANSFORMER in cabs2cil input")
   | A.EXPRTRANSFORMER (_, _, _) -> 
       E.s (E.bug "EXPRTRANSFORMER in cabs2cil input")
+  | A.STATIC_ASSERT _ -> empty
         
   (* If there are multiple definitions of extern inline, turn all but the 
    * first into a prototype *)

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -51,6 +51,7 @@ open Cabshelper
 open Pretty
 open Cil
 open Cilint
+open Expcompare
 open Trace
 
 
@@ -3053,7 +3054,6 @@ and doOnlyType (specs: A.spec_elem list) (dt: A.decl_type) : typ =
            d_attrlist nattr);
   tres
 
-
 and makeCompType (isstruct: bool)
                  (n: string)
                  (nglist: A.field_group list) 
@@ -4036,6 +4036,45 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
               (Lval tmp)
               intType
     end
+
+    | A.GENERIC (e, lst) ->
+      let compare_types t_1 t_2 =
+          match t_1, t_2 with
+            | Some t_1', Some t_2'  -> compareTypesNoAttributes t_1' t_2'
+            | _                     -> false
+        in
+
+        (* Map over all type "matches" [type_1:expr_1] defined in  _Generic(T, type_1: expr_1, ..., default: expr_n). *)
+        let mapped = List.map (fun (opt, exp) ->
+          match opt with
+          (* If None, then we've found the default. *)
+          | None -> (None, exp)
+          (* If Some, then we've found a type match (type_1 above above). Find the Cil.typ of this type. *)
+          | Some (spec, decl) ->
+              let declaration_type = doOnlyType spec decl in
+              (Some declaration_type, exp)
+        )
+        lst in
+
+        (* Find the type of the value fed to the generic expression (T above). *)
+        let (chunk, expr, t_typ) = doExp false e (AExp None) in
+        
+        (* Find the matching type in the type matches. *)
+        let found_match = List.find_opt (fun (match_type, e) -> compare_types (Some t_typ) match_type) mapped in
+        (* Find the default expression. *)
+        let found_default = List.find_opt (fun (match_type, e) -> match_type == None) mapped in
+
+        let res = match found_match, found_default with
+          (* A matching type in the assoc. list of _Generic was found,
+             find blockchunk and Cil expression for the matching expression. *)
+          | Some(Some res, exp), _ -> doExp false exp (AExp None)
+          (* No types matched, use the default expression. *)
+          | None, Some((None, exp)) -> doExp false exp (AExp None)
+          (* No types matched, raise an error.
+             We should hopefully see a compile time error before we reach this case. *)
+          | _ -> E.s (error "Could not find matching type for %a in _Generic @" d_plaintype t_typ)
+        in
+        res
 
     | A.CALL(f, args) -> 
         if asconst then

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -58,6 +58,7 @@ let get_definitionloc (d : definition) : cabsloc =
   | TRANSFORMER(_, _, l) -> l
   | EXPRTRANSFORMER(_, _, l) -> l
   | LINKAGE (_, l, _) -> l
+  | STATIC_ASSERT (_, _, l) -> l
 
 let get_statementloc (s : statement) : cabsloc =
 begin

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -531,6 +531,7 @@ and childrenExpression vis e =
       let b' = visitCabsBlock vis b in
       if b' != b then GNU_BODY b' else e
   | EXPR_PATTERN _ -> e
+  | GENERIC (expr, lst) -> GENERIC (ve expr, List.map (fun (opt, expr) -> (opt, ve expr)) lst)
         
 and visitCabsInitExpression vis (ie: init_expression) : init_expression = 
   doVisit vis vis#vinitexpr childrenInitExpression ie

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -333,6 +333,7 @@ and childrenDefinition vis d =
       
   | TRANSFORMER _ -> d
   | EXPRTRANSFORMER _ -> d
+  | STATIC_ASSERT _ -> d
         
 and visitCabsBlock vis (b: block) : block = 
   doVisit vis vis#vblock childrenBlock b

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -37,7 +37,7 @@
  *)
 (* FrontC -- lexical analyzer
 **
-** 1.0	3.22.99	Hugues Cassé	First version.
+** 1.0	3.22.99	Hugues CassÃ©	First version.
 ** 2.0  George Necula 12/12/00: Many extensions
 *)
 {
@@ -175,6 +175,7 @@ let init_lexicon _ =
       ("__typeof__", fun loc -> TYPEOF loc);
       ("__typeof", fun loc -> TYPEOF loc);
       ("typeof", fun loc -> TYPEOF loc); 
+      ("_Generic", fun loc -> GENERIC loc); 
       ("__alignof", fun loc -> ALIGNOF loc);
       ("__alignof__", fun loc -> ALIGNOF loc);
       ("__volatile__", fun loc -> VOLATILE loc);

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -37,7 +37,7 @@
  *)
 (* FrontC -- lexical analyzer
 **
-** 1.0	3.22.99	Hugues Cassé	First version.
+** 1.0	3.22.99	Hugues CassÈ	First version.
 ** 2.0  George Necula 12/12/00: Many extensions
 *)
 {
@@ -176,6 +176,7 @@ let init_lexicon _ =
       ("__typeof", fun loc -> TYPEOF loc);
       ("typeof", fun loc -> TYPEOF loc); 
       ("_Generic", fun loc -> GENERIC loc); 
+      ("_Static_assert", fun loc -> STATIC_ASSERT loc); 
       ("__alignof", fun loc -> ALIGNOF loc);
       ("__alignof__", fun loc -> ALIGNOF loc);
       ("__volatile__", fun loc -> VOLATILE loc);

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -36,7 +36,7 @@
  *
  **)
 (**
-** 1.0	3.22.99	Hugues Cassé	First version.
+** 1.0	3.22.99	Hugues CassÃ© 	First version.
 ** 2.0  George Necula 12/12/00: Practically complete rewrite.
 *)
 */
@@ -256,7 +256,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token EOF
 %token<Cabs.cabsloc> CHAR INT BOOL DOUBLE FLOAT VOID INT128 INT64 INT32
 %token<Cabs.cabsloc> ENUM STRUCT TYPEDEF UNION
-%token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT
+%token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT GENERIC
 %token<Cabs.cabsloc> VOLATILE EXTERN STATIC CONST RESTRICT AUTO REGISTER
 %token<Cabs.cabsloc> THREAD
 
@@ -469,10 +469,27 @@ primary_expression:                     /*(* 6.5.1. *)*/
 		        {PAREN (smooth_expression (fst $1)), snd $1}
 |		LPAREN block RPAREN
 		        { GNU_BODY (fst3 $2), $1 }
-
      /*(* Next is Scott's transformer *)*/
 |               AT_EXPR LPAREN IDENT RPAREN         /* expression pattern variable */
                          { EXPR_PATTERN(fst $3), $1 }
+| generic_selection
+    { $1 }
+
+generic_selection: 
+| GENERIC LPAREN assignment_expression COMMA generic_assoc_list RPAREN
+    { GENERIC((fst $3), $5), $1 }
+
+generic_assoc_list:
+| generic_association 
+    { [$1] }
+| generic_assoc_list COMMA generic_association
+    { $3 :: $1 }
+
+generic_association: 
+| type_name COLON assignment_expression
+    { Some($1), (fst $3) }
+| DEFAULT COLON assignment_expression
+    { None, (fst $3) }
 ;
 
 postfix_expression:                     /*(* 6.5.2 *)*/

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -36,7 +36,7 @@
  *
  **)
 (**
-** 1.0	3.22.99	Hugues Cassé 	First version.
+** 1.0	3.22.99	Hugues CassÈ 	First version.
 ** 2.0  George Necula 12/12/00: Practically complete rewrite.
 *)
 */
@@ -256,7 +256,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token EOF
 %token<Cabs.cabsloc> CHAR INT BOOL DOUBLE FLOAT VOID INT128 INT64 INT32
 %token<Cabs.cabsloc> ENUM STRUCT TYPEDEF UNION
-%token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT GENERIC
+%token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT GENERIC STATIC_ASSERT
 %token<Cabs.cabsloc> VOLATILE EXTERN STATIC CONST RESTRICT AUTO REGISTER
 %token<Cabs.cabsloc> THREAD
 
@@ -486,10 +486,16 @@ generic_assoc_list:
     { $3 :: $1 }
 
 generic_association: 
-| type_name COLON assignment_expression
+| type_name COLON expression
     { Some($1), (fst $3) }
-| DEFAULT COLON assignment_expression
+| DEFAULT COLON expression
     { None, (fst $3) }
+
+static_assert: 
+| STATIC_ASSERT LPAREN expression RPAREN
+    { STATIC_ASSERT (fst $3, None, $1) }
+| STATIC_ASSERT LPAREN expression COMMA string_constant RPAREN
+    { STATIC_ASSERT (fst $3, Some(fst $5), $1) }
 ;
 
 postfix_expression:                     /*(* 6.5.2 *)*/
@@ -946,6 +952,7 @@ declaration:                                /* ISO 6.7.*/
                                        { doDeclaration ((*handleLoc*)(snd $1)) (fst $1) $2 }
 |   decl_spec_list SEMICOLON	       
                                        { doDeclaration ((*handleLoc*)(snd $1)) (fst $1) [] }
+|   static_assert                      { $1 }
 ;
 init_declarator_list:                       /* ISO 6.7 */
     init_declarator                              { [$1] }
@@ -1527,6 +1534,7 @@ asmattr:
      /* empty */                        { [] }
 |    VOLATILE  asmattr                  { ("volatile", []) :: $2 }
 |    CONST asmattr                      { ("const", []) :: $2 } 
+|    INLINE asmattr                     { ("inline", []) :: $2 }
 ;
 asmtemplate: 
     one_string_constant                          { [$1] }

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -41,20 +41,20 @@
 ** File:	cprint.ml
 ** Version:	2.1e
 ** Date:	9.1.99
-** Author:	Hugues Cassé
+** Author:	Hugues CassÈ
 **
-**	1.0		2.22.99	Hugues Cassé	First version.
-**	2.0		3.18.99	Hugues Cassé	Compatible with Frontc 2.1, use of CAML
+**	1.0		2.22.99	Hugues CassÈ	First version.
+**	2.0		3.18.99	Hugues CassÈ	Compatible with Frontc 2.1, use of CAML
 **									pretty printer.
-**	2.1		3.22.99	Hugues Cassé	More efficient custom pretty printer used.
-**	2.1a	4.12.99	Hugues Cassé	Correctly handle:
+**	2.1		3.22.99	Hugues CassÈ	More efficient custom pretty printer used.
+**	2.1a	4.12.99	Hugues CassÈ	Correctly handle:
 **									char *m, *m, *p; m + (n - p)
-**	2.1b	4.15.99	Hugues Cassé	x + (y + z) stays x + (y + z) for
+**	2.1b	4.15.99	Hugues CassÈ	x + (y + z) stays x + (y + z) for
 **									keeping computation order.
-**	2.1c	7.23.99	Hugues Cassé	Improvement of case and default display.
-**	2.1d	8.25.99	Hugues Cassé	Rebuild escape sequences in string and
+**	2.1c	7.23.99	Hugues CassÈ	Improvement of case and default display.
+**	2.1d	8.25.99	Hugues CassÈ	Rebuild escape sequences in string and
 **									characters.
-**	2.1e	9.1.99	Hugues Cassé	Fix, recognize and correctly display '\0'.
+**	2.1e	9.1.99	Hugues CassÈ	Fix, recognize and correctly display '\0'.
 *)
 
 (* George Necula: I changed this pretty dramatically since CABS changed *)
@@ -62,7 +62,7 @@ open Cabs
 open Escape
 open Whitetrack
 
-let version = "Cprint 2.1e 9.1.99 Hugues Cassé"
+let version = "Cprint 2.1e 9.1.99 Hugues CassÈ"
 
 type loc = { line : int; file : string }
 
@@ -406,6 +406,7 @@ and get_operator exp =
   | MEMBEROFPTR (exp, fld) -> ("", 15)
   | GNU_BODY _ -> ("", 17)
   | EXPR_PATTERN _ -> ("", 16)     (* sm: not sure about this *)
+  | GENERIC _ -> ("", 16)
 
 and print_comma_exps exps =
   print_commas false print_expression exps
@@ -882,6 +883,7 @@ and print_def def =
       print_expression destexpr;
       print " }";
       force_new_line()
+  | STATIC_ASSERT _ -> ()
 
 
 (* sm: print a comment if the printComments flag is set *)

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -41,20 +41,20 @@
 ** File:	cprint.ml
 ** Version:	2.1e
 ** Date:	9.1.99
-** Author:	Hugues Cassé
+** Author:	Hugues CassÃ©
 **
-**	1.0		2.22.99	Hugues Cassé	First version.
-**	2.0		3.18.99	Hugues Cassé	Compatible with Frontc 2.1, use of CAML
+**	1.0		2.22.99	Hugues CassÃ©	First version.
+**	2.0		3.18.99	Hugues CassÃ©	Compatible with Frontc 2.1, use of CAML
 **									pretty printer.
-**	2.1		3.22.99	Hugues Cassé	More efficient custom pretty printer used.
-**	2.1a	4.12.99	Hugues Cassé	Correctly handle:
+**	2.1		3.22.99	Hugues CassÃ©	More efficient custom pretty printer used.
+**	2.1a	4.12.99	Hugues CassÃ©	Correctly handle:
 **									char *m, *m, *p; m + (n - p)
-**	2.1b	4.15.99	Hugues Cassé	x + (y + z) stays x + (y + z) for
+**	2.1b	4.15.99	Hugues CassÃ©	x + (y + z) stays x + (y + z) for
 **									keeping computation order.
-**	2.1c	7.23.99	Hugues Cassé	Improvement of case and default display.
-**	2.1d	8.25.99	Hugues Cassé	Rebuild escape sequences in string and
+**	2.1c	7.23.99	Hugues CassÃ©	Improvement of case and default display.
+**	2.1d	8.25.99	Hugues CassÃ©	Rebuild escape sequences in string and
 **									characters.
-**	2.1e	9.1.99	Hugues Cassé	Fix, recognize and correctly display '\0'.
+**	2.1e	9.1.99	Hugues CassÃ©	Fix, recognize and correctly display '\0'.
 *)
 
 (* George Necula: I changed this pretty dramatically since CABS changed *)
@@ -62,7 +62,7 @@ open Cabs
 open Escape
 open Whitetrack
 
-let version = "Cprint 2.1e 9.1.99 Hugues Cassé"
+let version = "Cprint 2.1e 9.1.99 Hugues CassÃ©"
 
 type loc = { line : int; file : string }
 
@@ -544,6 +544,7 @@ and print_expression_level (lvl: int) (exp : expression) =
       print ")"
   | EXPR_PATTERN (name) ->
       printl ["@expr";"(";name;")"]
+  | GENERIC _ -> print "_Generic(...)"
   in
   ()
     

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -207,20 +207,21 @@ let rem_quotes str = String.sub str 1 ((String.length str) - 2)
 
 (* Change \ into / in file names. To avoid complications with escapes *)
 let cleanFileName str = 
-  let str1 = 
-    if str <> "" && String.get str 0 = '"' (* '"' ( *) 
+  let str_ = 
+    if str <> "" && String.get str 0 = '"'
     then rem_quotes str else str in
-  let l = String.length str1 in
+  let str1 = Bytes.of_string str_ in
+  let l = Bytes.length str1 in
   let rec loop (copyto: int) (i: int) = 
     if i >= l then 
-      String.sub str1 0 copyto
+      Bytes.to_string (Bytes.sub str1 0 copyto)
      else 
-       let c = String.get str1 i in
+       let c = Bytes.get str1 i in
        if c <> '\\' then begin
-          String.set str1 copyto c; loop (copyto + 1) (i + 1)
+          Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
-          String.set str1 copyto '/';
-          if i < l - 2 && String.get str1 (i + 1) = '\\' then
+          Bytes.set str1 copyto '/';
+          if i < l - 2 && Bytes.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 
               loop (copyto + 1) (i + 1)

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -725,31 +725,31 @@ let gprintf (finish : doc -> 'b)
               invalid_arg ("dprintf: unimplemented format " 
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = Bytes.of_string "% " in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int64.format format_spec n))
+                         (Int64.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'l' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = Bytes.of_string "% " in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int32.format format_spec n))
+                         (Int32.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'n' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = Bytes.of_string "% " in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Nativeint.format format_spec n))
+                         (Nativeint.format (Bytes.to_string format_spec) n))
                 (succ j'))
         | 'f' | 'e' | 'E' | 'g' | 'G' ->
             Obj.magic(fun f ->


### PR DESCRIPTION
This PR adds support for C-11 `_Generic` expressions and will add parsing, type checking and `cabs2CIL` conversions for `_Generic` expressions, `_Static_assert` and inline ASM.